### PR TITLE
add 'no_browser' capability to bokeh plotter

### DIFF
--- a/frbpoppy/do_plot.py
+++ b/frbpoppy/do_plot.py
@@ -7,7 +7,7 @@ from frbpoppy.log import pprint
 from frbpoppy.paths import paths
 
 
-def plot(*pops, files=[], frbcat=True, show=True,
+def plot(*pops, files=[], frbcat=True, show=True, no_browser=False,
          mute=True, port=5006, print_command=False):
     """
     Plot populations with bokeh. Has to save populations before plotting.
@@ -44,7 +44,10 @@ def plot(*pops, files=[], frbcat=True, show=True,
     command = 'nice -n 19 '
 
     if show:
-        command += 'bokeh serve --show'
+        command += 'bokeh serve'
+        # Pop up a browser
+        if not no_browser:
+            command += ' --show'
     else:
         command += 'python3'
 


### PR DESCRIPTION
Useful if running code on a remote server (e.g. supercomputer) where a user doesn't want the remote host to launch the browser. User should make sure TCP portforwarding is set accordingly.